### PR TITLE
Verify Public Key.

### DIFF
--- a/circuits/bigint.circom
+++ b/circuits/bigint.circom
@@ -559,7 +559,7 @@ template CheckCarryToZero(n, m, k) {
             carry[i] <-- (in[i]+carry[i-1]) / (1<<n);
             in[i] + carry[i-1] === carry[i] * (1<<n);
         }
-        // checking carry is in the range of - 2^(m-n-1+eps), 2^(m+-n-1+eps)
+        // checking carry is in the range of - 2^(m-n-1+eps), 2^(m-n-1+eps)
         carryRangeChecks[i].in <== carry[i] + ( 1<< (m + EPSILON - n - 1));
     }
     in[k-1] + carry[k-2] === 0;   

--- a/circuits/ecdsa.circom
+++ b/circuits/ecdsa.circom
@@ -225,6 +225,60 @@ template ECDSAVerifyNoPubkeyCheck(n, k) {
     result <== res_comp.out;
 }
 
+// Checks pubkey is a valid public key by making sure its points are on the curve and that nQ = 0.
+// Algorithm from Johnson et al https://doi.org/10.1007/s102070100002 section 6.2
+template ECDSACheckPubKey(n, k) {
+    assert(n == 64 && k == 4);
+    signal input pubkey[2][k];
+
+    // Checks coordinates are in the base field, that Q is on the curve, and that Q != 0
+    component point_on_curve = Secp256k1PointOnCurve();
+    for (var i = 0; i < 4; i++) {
+        point_on_curve.x[i] <== pubkey[0][i];
+        point_on_curve.y[i] <== pubkey[1][i];
+    }
+
+    // We don't represent 0 as an actual point so we can't directly check that nQ = 0
+    // Instead we check that (n - 2)Q = 2(-Q)
+    // Note that we can't use (n - 1)Q = -Q since the double and add circuit implicitly tries to calculate nQ and errors
+    var order_minus_one[100] = get_secp256k1_order(n, k);
+    order_minus_one[0] -= 2;
+    
+    component lhs = Secp256k1ScalarMult(n, k);
+    for (var i = 0; i < k; i++) {
+        lhs.scalar[i] <== order_minus_one[i];
+    }
+    for (var i = 0; i < k; i++) {
+        lhs.point[0][i] <== pubkey[0][i];
+        lhs.point[1][i] <== pubkey[1][i];
+    }
+
+    // Check each coordinate of our equality independently.
+    // Note: Q = (x, y) => -Q = (x, -y)
+    // So we can check the x coordinate with [(n-1)*Q].x = Q.x,
+
+    // Because -y === p - y mod p,
+    //  we can check the y coordinate with [(n-1)*Q].y = p - Q.y
+    var prime[100] = get_secp256k1_prime(n, k);
+    component negative_y = BigSub(n, k);
+    for (var i = 0; i < k; i++) {
+        negative_y.a[i] <== prime[i];
+        negative_y.b[i] <== pubkey[1][i];
+    }
+    negative_y.underflow === 0;
+
+    component rhs = Secp256k1Double(n, k);
+    for (var i = 0; i < k; i++) {
+        rhs.in[0][i] <== pubkey[0][i];
+        rhs.in[1][i] <== negative_y.out[i];
+    }
+
+    for (var i = 0; i < k; i++) {
+        lhs.out[0][i] === rhs.out[0][i];
+        lhs.out[1][i] === rhs.out[1][i];
+    }
+}
+
 // TODO: implement ECDSA extended verify
 // r, s, and msghash have coordinates
 // encoded with k registers of n bits each

--- a/test/circuits/test_ecdsa_check_pub_key.circom
+++ b/test/circuits/test_ecdsa_check_pub_key.circom
@@ -1,0 +1,5 @@
+pragma circom 2.0.2;
+
+include "../../circuits/ecdsa.circom";
+
+component main {public [pubkey]} = ECDSACheckPubKey(64, 4);

--- a/test/ecdsa.test.ts
+++ b/test/ecdsa.test.ts
@@ -210,3 +210,41 @@ describe("ECDSAVerifyNoPubkeyCheck", function () {
 
     test_cases.forEach(test_ecdsa_verify);
 });
+
+
+describe("ECDSACheckPubKey", function () {
+    this.timeout(1000 * 1000);
+
+    var test_cases: Array<[bigint, bigint]> = [];
+    var privkeys: Array<bigint> = [
+        88549154299169935420064281163296845505587953610183896504176354567359434168161n,
+        37706893564732085918706190942542566344879680306879183356840008504374628845468n,
+        90388020393783788847120091912026443124559466591761394939671630294477859800601n,
+        110977009687373213104962226057480551605828725303063265716157300460694423838923n
+    ];
+
+    for (var idx = 0; idx < privkeys.length; idx++) {
+        var pubkey: Point = Point.fromPrivateKey(privkeys[idx]);
+        test_cases.push([pubkey.x, pubkey.y]);
+    }
+
+    let circuit: any;
+    before(async function () {
+        circuit = await wasm_tester(path.join(__dirname, "circuits", "test_ecdsa_check_pub_key.circom"));
+    });
+
+    var test_ecdsa_verify = function (test_case: [bigint, bigint]) {
+        let pub0 = test_case[0];
+        let pub1 = test_case[1];
+        
+        
+        var pub0_array: bigint[] = bigint_to_array(64, 4, pub0);
+        var pub1_array: bigint[] = bigint_to_array(64, 4, pub1);
+        it('Testing valid pub key: pub0: ' + pub0 + ' pub1: ' + pub1, async function() {
+            let witness = await circuit.calculateWitness({"pubkey": [pub0_array, pub1_array]});
+            await circuit.checkConstraints(witness);
+        });
+    }
+
+    test_cases.forEach(test_ecdsa_verify);
+});


### PR DESCRIPTION
Add public key verification circuit that checks that a point is on the curve and that it's in the subgroup using `(n-2)Q = 2(-Q)`. Note that calculating `nQ` or `(n-1)Q` with double and add both fail as they involve calculating `nQ` which can't be represented in projective coordinates.