### PR TITLE
fixing template ModSubThree

### DIFF
--- a/circuits/bigint.circom
+++ b/circuits/bigint.circom
@@ -35,22 +35,20 @@ template ModSub(n) {
 }
 
 // a - b - c
-// assume a - b - c + 2**n >= 0
+// checks a - b - c + 2**n >= 0
 template ModSubThree(n) {
     assert(n + 2 <= 253);
     signal input a;
     signal input b;
     signal input c;
-    assert(a - b - c + (1 << n) >= 0);
     signal output out;
     signal output borrow;
-    signal b_plus_c;
-    b_plus_c <== b + c;
-    component lt = LessThan(n + 1);
-    lt.in[0] <== a;
-    lt.in[1] <== b_plus_c;
-    borrow <== lt.out;
-    out <== borrow * (1 << n) + a - b_plus_c;
+    
+    component n2b = Num2Bits(n+2);
+    n2b.in <== (1 << (n + 1)) + a - b - c;
+    n2b.out[n+1] + n2b.out[n] === 1;
+    borrow <== 1 - n2b.out[n+1]; 
+    out <== borrow * (1 << n) + a - b - c;
 }
 
 template ModSumThree(n) {


### PR DESCRIPTION
### Template ModSubThree(n) accepts unexpected solutions when a - b - c + (1 << n) >= 0.

The template ModSubThree(n) receives three inputs a, b, c that can be expressed using n bits and performs the operation a - b - c. It returns the result of the operation using n bits (signal out), along with a signal indicating if there has been an underflow (borrow).

The condition a - b - c + (1 << n) >= 0 is introduced as an assert that is not checked at compile time as it is unknown (https://docs.circom.io/circom-language/code-quality/code-assertion/). The assert is only included in the witness generation code but it is not added to the constraint system describing the circuit, which may generate unexpected behaviors. 

For example, for n = 3, the constraints of ModSubThree(3) for the inputs a = 0, b = 7, c = 7 are satisfied by the output borrow = 1, out = -6. However, this solution does not satisfy the specification of the circuit as out cannot be expressed using 3 bits.

The proposed fix incorporates the check a - b - c + (1 << n) >= 0 to the constraint system without adding extra constraints (same number of non-linear constraints, less linear constraints) by using a call to Num2Bits to both compute the value of borrow and perform this check.